### PR TITLE
fix: rename config to btnConfig to resolve export warning

### DIFF
--- a/src/components/Button/Button.constant.ts
+++ b/src/components/Button/Button.constant.ts
@@ -58,7 +58,7 @@ export const sizes = {
   xl: 'px-4 py-2 text-lg leading-8',
 } as const;
 
-export const config: Record<ButtonVariant, ButtonConfig> = {
+export const btnConfig: Record<ButtonVariant, ButtonConfig> = {
   primary: {
     shape: 'circular',
     width: 'fit',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { aligns, colors, config, shapes, sizes, widths } from './Button.constant';
+import { aligns, btnConfig, colors, shapes, sizes, widths } from './Button.constant';
 
 export type ButtonVariant =
   | 'primary'
@@ -19,7 +19,7 @@ interface Props extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'dis
 }
 
 export const Button = ({ children, variant = 'primary', disabled = false, leftIcon, rightIcon, ...props }: Props) => {
-  const { shape, width, align, color, size, type } = config[variant];
+  const { shape, width, align, color, size, type } = btnConfig[variant];
   const baseClass = 'flex gap-1 items-center text-sm font-bold flex-shrink-0';
   const validClass = disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:opacity-90 transition-opacity';
 


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- `config` 로 export 시 발생하는 warning 해결하기 위해 네이밍 변경 

### 상세 작업 내용

## 디자인 (스크린샷)

## TODO
