### PR TITLE
fix: resolve backdrop click not closing modal

### DIFF
--- a/src/components/Modal/ModalAction/ModalAction.tsx
+++ b/src/components/Modal/ModalAction/ModalAction.tsx
@@ -1,13 +1,7 @@
-import { FocusTrap } from 'focus-trap-react';
-
 interface Props {
   children: React.ReactNode;
 }
 
 export const ModalAction = ({ children }: Props) => {
-  return (
-    <FocusTrap>
-      <div className={`flex w-full gap-2`}>{children}</div>
-    </FocusTrap>
-  );
+  return <div className={`flex w-full gap-2`}>{children}</div>;
 };

--- a/src/components/Modal/ModalRoot/ModalRoot.tsx
+++ b/src/components/Modal/ModalRoot/ModalRoot.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { FocusTrap } from 'focus-trap-react';
 import { useEffect } from 'react';
 
 import { Backdrop } from '@/components/Backdrop/Backdrop';
@@ -50,12 +51,23 @@ export const ModalRoot = ({ isOpen, onClose, children, closeOnBackdropClick = tr
     <Portal>
       <div className="fixed left-0 right-0 bottom-0 z-50 flex items-center justify-center p-2">
         <Backdrop onClick={onClickBackdrop} />
-        <div
-          className="relative bg-bg-card rounded-2xl shadow-default max-w-sm w-full max-h-[90vh] overflow-auto transform transition-all duration-300 ease-out scale-100"
-          onClick={onClickModal}
+        <FocusTrap
+          focusTrapOptions={{
+            fallbackFocus: () => document.body,
+            escapeDeactivates: false,
+            clickOutsideDeactivates: closeOnBackdropClick,
+          }}
         >
-          <div className="p-5">{children}</div>
-        </div>
+          <div
+            className="relative bg-bg-card rounded-2xl shadow-default max-w-sm w-full max-h-[90vh] overflow-auto transform transition-all duration-300 ease-out scale-100 z-100"
+            onClick={onClickModal}
+            data-testid="modal-content"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="p-5">{children}</div>
+          </div>
+        </FocusTrap>
       </div>
     </Portal>
   );


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- Backdrop 컴포넌트를 클릭해도 모달 닫히지 않는 에러 해결

### 상세 작업 내용

- FocusTrap wrapper 위치를 Root 로 이동시킴
- focusTrapOptions 설정

## 디자인 (스크린샷)

## TODO
