### PR TITLE
feat: add hover tooltips to navigation bar items

### DIFF
--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -1,5 +1,7 @@
 import { NavMenuItem } from '../NavMenuItem/NavMenuItem';
+import { tabs } from '../NavMenuItem/NavMenuItem.constant';
 import { NavMenuList } from '../NavMenuList/NavMenuList';
+import { TooltipContainer } from '../TooltipContainer/TooltipContainer';
 
 interface Props {
   showLabel: boolean;
@@ -8,10 +10,18 @@ interface Props {
 export const NavMenu = ({ showLabel }: Props) => {
   return (
     <NavMenuList>
-      <NavMenuItem type="new" showLabel={showLabel} />
-      <NavMenuItem type="home" showLabel={showLabel} />
-      <NavMenuItem type="favorite" showLabel={showLabel} />
-      <NavMenuItem type="archive" showLabel={showLabel} />
+      <TooltipContainer text={tabs.new.label} showTooltip={!showLabel}>
+        <NavMenuItem type="new" showLabel={showLabel} />
+      </TooltipContainer>
+      <TooltipContainer text={tabs.home.label} showTooltip={!showLabel}>
+        <NavMenuItem type="home" showLabel={showLabel} />
+      </TooltipContainer>
+      <TooltipContainer text={tabs.favorite.label} showTooltip={!showLabel}>
+        <NavMenuItem type="favorite" showLabel={showLabel} />
+      </TooltipContainer>
+      <TooltipContainer text={tabs.archive.label} showTooltip={!showLabel}>
+        <NavMenuItem type="archive" showLabel={showLabel} />
+      </TooltipContainer>
     </NavMenuList>
   );
 };

--- a/src/components/NavigationBar/DesktopNavBar/DesktopNavBar.tsx
+++ b/src/components/NavigationBar/DesktopNavBar/DesktopNavBar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { NavMenu } from '@/components/NavMenu/NavMenu';
 import { NavToggleBtn } from '@/components/NavToggleBtn/NavToggleBtn';
+import { TooltipContainer } from '@/components/TooltipContainer/TooltipContainer';
 import { UserProfileMenu } from '@/components/UserProfileMenu/UserProfileMenu';
 
 import { FullNavBar } from '../FullNavBar/FullNavBar';
@@ -21,7 +22,9 @@ export const DesktopNavBar = () => {
     <nav className="h-dvh bg-bg-panel w-12 border-r border-r-border p-2 flex flex-col justify-between z-20">
       <div>
         <div className="mb-4">
-          <NavToggleBtn onClick={toggle} />
+          <TooltipContainer text="메뉴 열기" showTooltip>
+            <NavToggleBtn onClick={toggle} />
+          </TooltipContainer>
         </div>
         <NavMenu showLabel={false} />
       </div>

--- a/src/components/NavigationBar/FullNavBar/FullNavBar.tsx
+++ b/src/components/NavigationBar/FullNavBar/FullNavBar.tsx
@@ -2,6 +2,7 @@ import { Logo } from '@/components/Logo/Logo';
 import { NavItem } from '@/components/NavItem/NavItem';
 import { NavMenu } from '@/components/NavMenu/NavMenu';
 import { NavToggleBtn } from '@/components/NavToggleBtn/NavToggleBtn';
+import { TooltipContainer } from '@/components/TooltipContainer/TooltipContainer';
 import { UserProfileMenu } from '@/components/UserProfileMenu/UserProfileMenu';
 
 import { BottomSection } from '../BottomSection/BottomSection';
@@ -34,7 +35,9 @@ export const FullNavBar = ({ toggle, isMobile }: Props) => {
       {/* Header */}
       <div>
         <div className="flex gap-1 p-2 items-center">
-          <NavToggleBtn onClick={toggle} />
+          <TooltipContainer text="메뉴 접기">
+            <NavToggleBtn onClick={toggle} />
+          </TooltipContainer>
           <Logo size="sm" />
         </div>
       </div>

--- a/src/components/NavigationBar/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/NavigationBar/MobileNavBar/MobileNavBar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Logo } from '@/components/Logo/Logo';
 import { NavToggleBtn } from '@/components/NavToggleBtn/NavToggleBtn';
+import { TooltipContainer } from '@/components/TooltipContainer/TooltipContainer';
 
 import { FullNavBar } from '../FullNavBar/FullNavBar';
 import { MobileNavRightBtn } from '../MobileNavRightBtn/MobileNavRightBtn';
@@ -21,7 +22,9 @@ export const MobileNavBar = () => {
     <>
       <div className="h-12 w-full grid grid-cols-3 items-center p-2 border-b border-b-border z-20 bg-bg-body">
         <div className="flex justify-start items-center">
-          <NavToggleBtn onClick={toggle} />
+          <TooltipContainer text="메뉴 열기">
+            <NavToggleBtn onClick={toggle} />
+          </TooltipContainer>
         </div>
 
         <div className="flex justify-center items-center">

--- a/src/components/TooltipContainer/TooltipContainer.tsx
+++ b/src/components/TooltipContainer/TooltipContainer.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  text?: string;
+  showTooltip?: boolean;
+}
+
+export const TooltipContainer = ({ children, text, showTooltip = true }: Props) => {
+  const [isHover, setIsHover] = useState(false);
+
+  if (!showTooltip) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="relative" onMouseEnter={() => setIsHover(true)} onMouseLeave={() => setIsHover(false)}>
+      {children}
+      {isHover && (
+        <div className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 z-50 pointer-events-none">
+          <div className="bg-black text-white text-[10px] font-bold opacity-90 px-2 py-1 rounded-lg shadow-lg whitespace-nowrap">
+            {text}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- 네비게이션 바 아이템에 hover 시 tooltip 추가

### 상세 작업 내용

- TooltipConatiner 개발
  - isHover 상태로 툴팁 관리
  - realtive, absolute 로 툴팁 위치 정함

## 디자인 (스크린샷)

<img width="480" src="https://github.com/user-attachments/assets/f50f3d9a-1e83-46c8-96c7-6efa2524b5d6" />

## TODO

- [ ] 현재는 오른쪽으로 고정, 추후 왼쪽, 위, 아래 등 스타일 지정하도록 