### PR TITLE
feat: remove recent books from full navigation bar

### DIFF
--- a/src/components/layout/NavigationBar/DesktopNavBar/DesktopNavBar.tsx
+++ b/src/components/layout/NavigationBar/DesktopNavBar/DesktopNavBar.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
 import { NavMenu } from '@/components/layout/NavMenu/NavMenu';
-import { NavToggleBtn } from '@/components/layout/NavToggleBtn/NavToggleBtn';
 import { TooltipContainer } from '@/components/modal/TooltipContainer/TooltipContainer';
 import { UserProfileMenu } from '@/components/user/UserProfileMenu/UserProfileMenu';
 
+import { NavToggleBtn } from '../../NavToggleBtn/NavToggleBtn';
 import { FullNavBar } from '../FullNavBar/FullNavBar';
 
 export const DesktopNavBar = () => {

--- a/src/components/layout/NavigationBar/FullNavBar/FullNavBar.tsx
+++ b/src/components/layout/NavigationBar/FullNavBar/FullNavBar.tsx
@@ -1,14 +1,10 @@
 import { Logo } from '@/components/common/ui/Logo/Logo';
-import { NavItem } from '@/components/layout/NavItem/NavItem';
 import { NavMenu } from '@/components/layout/NavMenu/NavMenu';
 import { NavToggleBtn } from '@/components/layout/NavToggleBtn/NavToggleBtn';
 import { TooltipContainer } from '@/components/modal/TooltipContainer/TooltipContainer';
 import { UserProfileMenu } from '@/components/user/UserProfileMenu/UserProfileMenu';
 
 import { BottomSection } from '../BottomSection/BottomSection';
-import { NavContent } from '../Content/Content';
-import { NavContentSection } from '../ContentSection/ContentSection';
-import { NavContentTitle } from '../ContentTitle/ContentTitle';
 
 interface Props {
   toggle: () => void;
@@ -16,12 +12,7 @@ interface Props {
 }
 
 export const FullNavBar = ({ toggle, isMobile }: Props) => {
-  const RECENT_BOOK = {
-    title: '내 문장이 그렇게 이상한가요? · 김정선',
-    href: '/',
-  };
-  const RECENT_BOOKS = Array.from({ length: 13 }, () => RECENT_BOOK);
-  const widthClass = isMobile ? 'w-3/4 fixed top-0 left-0 bottom-0 z-50' : 'relative w-3xs max-w-3xs';
+  const widthClass = isMobile ? 'w-3/4 fixed top-0 left-0 bottom-0 z-50' : 'relative w-60 max-60';
 
   return (
     <nav
@@ -43,23 +34,9 @@ export const FullNavBar = ({ toggle, isMobile }: Props) => {
       </div>
 
       {/* Navigation */}
-      <div className="m-2 mb-0">
+      <div className="m-2 mb-0 flex-1">
         <NavMenu showLabel />
       </div>
-
-      {/* Recent Books */}
-      <NavContentSection>
-        <NavContentTitle title="최근 읽은 책" />
-        <NavContent>
-          <NavItem href="/">여름은 오래 그곳에 남아 · 마쓰이에 마사시</NavItem>
-          <NavItem href="/">모순 · 양귀자</NavItem>
-          {RECENT_BOOKS.map((book, i) => (
-            <NavItem key={i} href={book.href}>
-              {book.title}
-            </NavItem>
-          ))}
-        </NavContent>
-      </NavContentSection>
 
       {/* User */}
       <BottomSection>


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- 네비게이션 바에 recent books 제거

### 상세 작업 내용

- 사용성을 고려했을 때 recent books 를 전환할 일이 많지 않을 것 같아 삭제 

## 디자인 (스크린샷)

<img width="240" height="301" alt="스크린샷 2025-08-05 오후 7 12 59" src="https://github.com/user-attachments/assets/e5742e85-5d94-49fb-9a86-db0501c87955" />

## TODO
