### PR TITLE
feat: display quote count only when count > 0

### DIFF
--- a/src/components/book/BookCard/BookCard.tsx
+++ b/src/components/book/BookCard/BookCard.tsx
@@ -27,7 +27,7 @@ export const BookCard = ({ id, title, author, thumbnail, startAt, endAt, count }
               <h3 className="text-sm line-clamp-2 leading-6 font-bold">{title}</h3>
               <p className="text-xs line-clamp-1 leading-6">{author}</p>
             </div>
-            <div className="flex justify-between items-center flex-wrap gap-1">
+            <div className="flex justify-between items-center flex-wrap gap-1 h-6">
               <p className="text-[10px] text-text-muted line-clamp-1">{period}</p>
               {!!count && (
                 <div className="flex justify-end flex-1">


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- BookCard 의 count badge 조건부 렌더링

### 상세 작업 내용

- count === 0 일 때 count badge를 렌더링 하지 않도록 함
- badge 없을 때도 동일한 레이아웃 유지하도록 height 고정 

## 디자인 (스크린샷)

<img width="480" src="https://github.com/user-attachments/assets/c38a645c-9120-4757-a8c6-eebb0fdf9010" />

## TODO
