### PR TITLE
feat: add archive page and empty state

### DIFF
--- a/src/app/(main)/archive/page.tsx
+++ b/src/app/(main)/archive/page.tsx
@@ -7,36 +7,36 @@ import { mapToBookCard } from '@/lib/mappers/bookMapper';
 import { bookService } from '@/services/bookService';
 import { BookCardItem } from '@/types/domain/book';
 
-export default async function FavoritePage() {
+export default async function ArchivePage() {
   const authData = await getServerAuthData();
   const accessToken = authData?.accessToken;
 
-  let favorites: BookCardItem[] = [];
+  let books: BookCardItem[] = [];
   let error: ApiError | null = null;
 
   if (accessToken) {
     try {
-      const data = await bookService.getBooks({ isFavorite: true }, accessToken);
-      favorites = data.map(mapToBookCard);
+      const data = await bookService.getBooks({}, accessToken);
+      books = data.map(mapToBookCard);
     } catch (err) {
       error = err as ApiError;
-      console.error('main page fetch books failed:', error);
+      console.error('archive page fetch books failed:', error);
     }
   }
 
-  if (favorites.length === 0) {
+  if (books.length === 0) {
     return (
       <div className="w-full max-w-7xl p-4">
-        <EmptyState type="favorite" />
+        <EmptyState type="all" />
       </div>
     );
   }
 
   return (
     <div className="w-full max-w-7xl p-4">
-      {favorites.length > 0 && (
-        <GridSection label={`즐겨찾는 책 (${favorites.length})`}>
-          {favorites.map((book) => (
+      {books.length > 0 && (
+        <GridSection label={`전체 (${books.length})`} hideBorder>
+          {books.map((book) => (
             <BookCard
               key={book.id}
               id={book.id}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,5 +1,7 @@
+import Link from 'next/link';
+
 import { BookCard } from '@/components/book/BookCard/BookCard';
-import { MainBookSupport } from '@/components/book/MainBookSupport/MainBookSupport';
+import { EmptyState } from '@/components/book/EmptyState/EmptyState';
 import { NowBookContent } from '@/components/book/NowBookContent/NowBookContent';
 import { NowBookHeader } from '@/components/book/NowBookHeader/NowBookHeader';
 import { RecentBookTitle } from '@/components/book/RecentBookTitle/RecentBookTitle';
@@ -40,7 +42,7 @@ export default async function Home() {
   if (books.length === 0) {
     return (
       <div className="w-full max-w-7xl p-4">
-        <MainBookSupport />
+        <EmptyState type="all" />
       </div>
     );
   }
@@ -107,23 +109,11 @@ export default async function Home() {
         </GridSection>
       )}
 
-      {/* favorites */}
-      {books.length > 0 && (
-        <GridSection label={`전체 (${books.length})`}>
-          {books.map((book) => (
-            <BookCard
-              key={book.id}
-              id={book.id}
-              author={book.author}
-              count={book.quoteCount}
-              endAt={book.endDate}
-              startAt={book.startDate}
-              thumbnail={book.thumbnail}
-              title={book.title}
-            />
-          ))}
-        </GridSection>
-      )}
+      <div className="pb-4 flex justify-center">
+        <Link className="px-3 py-1.5 text-xs bg-btn-subtle text-secondary rounded-full" href="/archive">
+          기록한 책 전체 보기
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/book/EmptyState/EmptyState.constant.ts
+++ b/src/components/book/EmptyState/EmptyState.constant.ts
@@ -1,0 +1,14 @@
+export const emptyConfig = {
+  all: {
+    primaryText: '반가워요 👋',
+    secondaryText: '지금 읽고 있는 책을 검색해 보세요',
+    buttonText: '시작하기',
+    redirectPath: '/search',
+  },
+  favorite: {
+    primaryText: '즐겨찾는 책이 없네요 👀',
+    secondaryText: '마음에 드는 책을 즐겨찾기 해보세요',
+    buttonText: '홈으로',
+    redirectPath: '/',
+  },
+} as const;

--- a/src/components/book/EmptyState/EmptyState.tsx
+++ b/src/components/book/EmptyState/EmptyState.tsx
@@ -7,14 +7,21 @@ import { useAuth } from '@/hooks';
 import { Button } from '../../common/ui/Button/Button';
 import { Txt } from '../../common/ui/Txt/Txt';
 
-export const MainBookSupport = () => {
+import { emptyConfig } from './EmptyState.constant';
+
+interface Props {
+  type: 'all' | 'favorite';
+}
+
+export const EmptyState = ({ type }: Props) => {
   const { user } = useAuth();
   const router = useRouter();
 
-  const name = `${user?.username}님, ` || '';
+  const { primaryText, secondaryText, buttonText, redirectPath } = emptyConfig[type];
+  const name = `${user?.username}님,` || '';
 
   const onClick = () => {
-    router.push('/search');
+    router.push(redirectPath);
   };
 
   return (
@@ -22,10 +29,12 @@ export const MainBookSupport = () => {
       <div className="flex-1 flex justify-center items-center py-10">
         <div className="pt-4 pb-8 h-full flex flex-col items-center justify-center">
           <div className="mb-4 text-center whitespace-pre-wrap">
-            <Txt variant="captionSm">{name}반가워요 👋</Txt>
-            <Txt variant="captionSm">지금 읽고 있는 책을 검색해 보세요</Txt>
+            <Txt variant="captionSm">
+              {name} {primaryText}
+            </Txt>
+            <Txt variant="captionSm">{secondaryText}</Txt>
           </div>
-          <Button onClick={onClick}>시작하기</Button>
+          <Button onClick={onClick}>{buttonText}</Button>
         </div>
       </div>
     </div>

--- a/src/components/layout/GridSection/GridSection.tsx
+++ b/src/components/layout/GridSection/GridSection.tsx
@@ -3,12 +3,14 @@ import { Txt } from '../../common/ui/Txt/Txt';
 interface Props extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
   label?: string;
+  hideBorder?: boolean;
 }
 
-export const GridSection = ({ children, label }: Props) => {
+export const GridSection = ({ children, label, hideBorder }: Props) => {
+  const borderClass = hideBorder ? 'pb-6' : 'border-t border-t-border pt-4 pb-6';
   return (
-    <section className="border-t border-t-border pb-6">
-      <div className="py-4">{!!label && <Txt variant="muted">{label}</Txt>}</div>
+    <section className={borderClass}>
+      <div className="pb-4">{!!label && <Txt variant="muted">{label}</Txt>}</div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 auto-rows-fr">{children}</div>
     </section>
   );


### PR DESCRIPTION
## PR 설명

### 어떤 기능인가요?

- `/archive` 페이지 생성 

### 상세 작업 내용

- 기존 메인 페이지에서 all books 를 display 하는 방식에서 `/archive` 페이지로 이동
- 기존의 MainBookSupport 컴포넌트를 재사용하도록 EmptyState 로 변경 및 확장 
- EmptyState 관련 content 는 constant 로 정의 

## 디자인 (스크린샷)

## TODO
